### PR TITLE
v6: globalfee enforcement + admin & btc-relayer fee exemption + 1500ms blocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,7 +300,7 @@ testnet: setup-testnet
 	spawn local-ic start testnet
 
 sh-testnet: mod-tidy
-	CHAIN_ID="localchain-1" BLOCK_TIME="1000ms" CLEAN=true sh scripts/test_ics_node.sh
+	CHAIN_ID="localchain-1" BLOCK_TIME="1500ms" CLEAN=true sh scripts/test_ics_node.sh
 
 .PHONY: setup-testnet set-testnet-configs testnet testnet-basic sh-testnet
 

--- a/app/ante.go
+++ b/app/ante.go
@@ -34,7 +34,9 @@ type HandlerOptions struct {
 
 	GlobalFeeKeeper      globalfeekeeper.Keeper
 	BypassMinFeeMsgTypes []string
-	// ConsumerKeeper       ccvconsumerkeeper.Keeper
+	// ExemptAddresses is the list of bech32 addresses that pay zero fees.
+	// Populated from the v6 upgrade params; defaults to empty at genesis.
+	ExemptAddresses []string
 }
 
 // NewAnteHandler constructor
@@ -58,9 +60,27 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		return nil, errors.New("circuit keeper is required for ante builder")
 	}
 
+	// postFeeDecorators is everything that runs AFTER fee checking.
+	// We need this as a standalone handler so that the exemption decorator
+	// can jump directly to it, skipping globalfeeante.FeeDecorator.
+	postFeeDecorators := []sdk.AnteDecorator{
+		ante.NewSetPubKeyDecorator(options.AccountKeeper),
+		ante.NewValidateSigCountDecorator(options.AccountKeeper),
+		ante.NewSigGasConsumeDecorator(options.AccountKeeper, options.SigGasConsumer),
+		ante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
+		ante.NewIncrementSequenceDecorator(options.AccountKeeper),
+		decorators.NewMsgStakingVestingDeny(options.AccountKeeper),
+		ibcante.NewRedundantRelayDecorator(options.IBCKeeper),
+	}
+	postFeeHandler := sdk.ChainAnteDecorators(postFeeDecorators...)
+
+	// Full ante chain. FeeExemptionAnteDecorator sits immediately before
+	// globalfeeante.FeeDecorator. Exempt signers jump to postFeeHandler;
+	// everyone else falls through to FeeDecorator then postFeeDecorators
+	// (which are also appended below so non-exempt paths remain correct).
 	anteDecorators := []sdk.AnteDecorator{
-		ante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
-		wasmkeeper.NewLimitSimulationGasDecorator(options.WasmConfig.SimulationGasLimit), // after setup context to enforce limits early
+		ante.NewSetUpContextDecorator(),
+		wasmkeeper.NewLimitSimulationGasDecorator(options.WasmConfig.SimulationGasLimit),
 		wasmkeeper.NewCountTXDecorator(options.TXCounterStoreService),
 		wasmkeeper.NewGasRegisterDecorator(options.WasmKeeper.GetGasRegister()),
 		circuitante.NewCircuitBreakerDecorator(options.CircuitKeeper),
@@ -69,9 +89,11 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		ante.NewTxTimeoutHeightDecorator(),
 		ante.NewValidateMemoDecorator(options.AccountKeeper),
 		ante.NewConsumeGasForTxSizeDecorator(options.AccountKeeper),
+		// Fee exemption MUST come before globalfee FeeDecorator.
+		decorators.NewFeeExemptionAnteDecorator(options.ExemptAddresses, postFeeHandler),
 		globalfeeante.NewFeeDecorator(options.BypassMinFeeMsgTypes, options.GlobalFeeKeeper, 2_000_000),
-		//ante.NewDeductFeeDecorator(options.AccountKeeper, options.BankKeeper, options.FeegrantKeeper, options.TxFeeChecker),
-		ante.NewSetPubKeyDecorator(options.AccountKeeper), // SetPubKeyDecorator must be called before all signature verification decorators
+		// Post-fee decorators run for non-exempt paths (exempt paths use postFeeHandler above).
+		ante.NewSetPubKeyDecorator(options.AccountKeeper),
 		ante.NewValidateSigCountDecorator(options.AccountKeeper),
 		ante.NewSigGasConsumeDecorator(options.AccountKeeper, options.SigGasConsumer),
 		ante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),

--- a/app/app.go
+++ b/app/app.go
@@ -272,6 +272,9 @@ type ChainApp struct {
 	TokenFactoryKeeper  tokenfactorykeeper.Keeper
 	GlobalFeeKeeper     globalfeekeeper.Keeper
 	PacketForwardKeeper *packetforwardkeeper.Keeper
+	// FeeExemptAddresses: bech32 addresses exempt from globalfee minimum gas price checks.
+	// Wired at startup; initially empty (all addresses pay fees). Populated by v6 upgrade.
+	FeeExemptAddresses []string
 
 	ScopedIBCKeeper           capabilitykeeper.ScopedKeeper
 	ScopedICAHostKeeper       capabilitykeeper.ScopedKeeper
@@ -1065,6 +1068,7 @@ func NewChainApp(
 
 			GlobalFeeKeeper:      app.GlobalFeeKeeper,
 			BypassMinFeeMsgTypes: GetDefaultBypassFeeMessages(),
+			ExemptAddresses:      app.FeeExemptAddresses,
 			// ConsumerKeeper:       app.ConsumerKeeper,
 		},
 	)
@@ -1133,6 +1137,9 @@ func NewChainApp(
 		}
 
 	}
+
+	// v6: fee-exempt admin address wired at startup (ante chain bypass).
+	app.FeeExemptAddresses = []string{"dungeon13x4pynlp86prhcmtns742kgsgu7pjtzj72eycc"}
 
 	return app
 }

--- a/app/app.go
+++ b/app/app.go
@@ -1050,6 +1050,10 @@ func NewChainApp(
 	app.SetPreBlocker(app.PreBlocker)
 	app.SetBeginBlocker(app.BeginBlocker)
 	app.SetEndBlocker(app.EndBlocker)
+	// v6: initialize fee-exempt addresses BEFORE building the ante handler.
+	// These must be set before NewAnteHandler is called or ExemptAddresses will be nil.
+	app.FeeExemptAddresses = []string{"dungeon13x4pynlp86prhcmtns742kgsgu7pjtzj72eycc"}
+
 
 	anteHandler, err := NewAnteHandler(
 		HandlerOptions{
@@ -1137,9 +1141,6 @@ func NewChainApp(
 		}
 
 	}
-
-	// v6: fee-exempt admin address wired at startup (ante chain bypass).
-	app.FeeExemptAddresses = []string{"dungeon13x4pynlp86prhcmtns742kgsgu7pjtzj72eycc"}
 
 	return app
 }

--- a/app/app.go
+++ b/app/app.go
@@ -1052,7 +1052,10 @@ func NewChainApp(
 	app.SetEndBlocker(app.EndBlocker)
 	// v6: initialize fee-exempt addresses BEFORE building the ante handler.
 	// These must be set before NewAnteHandler is called or ExemptAddresses will be nil.
-	app.FeeExemptAddresses = []string{"dungeon13x4pynlp86prhcmtns742kgsgu7pjtzj72eycc"}
+	app.FeeExemptAddresses = []string{
+		"dungeon13x4pynlp86prhcmtns742kgsgu7pjtzj72eycc", // admin / treasury
+		"dungeon1dflpa6dnpkn5ft4tyzkpwdhvz6l7wng06qn665", // btc-relayer (Phase A 2026-05-09)
+	}
 
 
 	anteHandler, err := NewAnteHandler(

--- a/app/decorators/fee_exempt.go
+++ b/app/decorators/fee_exempt.go
@@ -1,0 +1,73 @@
+package decorators
+
+import (
+	errorsmod "cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+// FeeExemptionAnteDecorator short-circuits fee checking for a configurable list
+// of bech32 addresses. Wire this decorator BEFORE the fee decorator(s) in the
+// ante chain and pass skipNext as the handler that represents "everything after
+// the fee decorator(s)". When a signer is exempt this decorator calls skipNext
+// directly, bypassing the fee decorator. For non-exempt signers it falls through
+// to the normal next handler (which IS the fee decorator).
+//
+// Wiring pattern in NewAnteHandler:
+//
+//	postFeeHandler := sdk.ChainAnteDecorators(SetPubKey, ValidateSigCount, ...)
+//	exemption := NewFeeExemptionAnteDecorator(exemptAddrs, postFeeHandler)
+//	// Then exemption sits before globalfeeante.NewFeeDecorator in the outer chain.
+//
+// Because the SDK chains decorators by threading next pointers, the exemption
+// decorator receives globalfee as its "next". When the address is exempt it
+// calls skipToHandler (which skips globalfee); otherwise it calls next (globalfee
+// runs normally).
+type FeeExemptionAnteDecorator struct {
+	exemptAddresses map[string]struct{}
+	// skipToHandler is called directly when the fee payer is exempt,
+	// bypassing whatever decorator comes next in the chain (the fee checker).
+	skipToHandler sdk.AnteHandler
+}
+
+// NewFeeExemptionAnteDecorator constructs the decorator.
+//
+//   - addresses: bech32 addresses that pay zero fees.
+//   - skipToHandler: the sdk.AnteHandler to invoke when an address is exempt
+//     (i.e. the portion of the ante chain AFTER the fee decorator).
+func NewFeeExemptionAnteDecorator(addresses []string, skipToHandler sdk.AnteHandler) FeeExemptionAnteDecorator {
+	m := make(map[string]struct{}, len(addresses))
+	for _, a := range addresses {
+		m[a] = struct{}{}
+	}
+	return FeeExemptionAnteDecorator{
+		exemptAddresses: m,
+		skipToHandler:   skipToHandler,
+	}
+}
+
+// AnteHandle implements sdk.AnteDecorator.
+// Checks the fee payer (FeeTx.FeePayer) against the exempt list.
+// If found, jumps directly to skipToHandler, bypassing all subsequent fee decorators.
+func (d FeeExemptionAnteDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	if simulate {
+		return next(ctx, tx, simulate)
+	}
+
+	feeTx, ok := tx.(sdk.FeeTx)
+	if !ok {
+		return ctx, errorsmod.Wrap(sdkerrors.ErrTxDecode, "Tx must implement sdk.FeeTx")
+	}
+
+	feePayer := feeTx.FeePayer()
+	if len(feePayer) > 0 {
+		feePayerAddr := sdk.AccAddress(feePayer).String()
+		if _, exempt := d.exemptAddresses[feePayerAddr]; exempt {
+			// Jump past fee decorator(s) directly to post-fee handlers.
+			return d.skipToHandler(ctx, tx, simulate)
+		}
+	}
+
+	// Not exempt — let the fee decorator (next in chain) run normally.
+	return next(ctx, tx, simulate)
+}

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	v4 "github.com/Crypto-Dungeon/dungeonchain/app/upgrades/v4"
 	v5 "github.com/Crypto-Dungeon/dungeonchain/app/upgrades/v5"
+	v6 "github.com/Crypto-Dungeon/dungeonchain/app/upgrades/v6"
 
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 
@@ -12,7 +13,7 @@ import (
 )
 
 // Upgrades list of chain upgrades
-var Upgrades = []upgrades.Upgrade{v5.Upgrade}
+var Upgrades = []upgrades.Upgrade{v5.Upgrade, v6.Upgrade}
 var Forks = []upgrades.Fork{v4.Upgrade}
 
 // RegisterUpgradeHandlers registers the chain upgrade handlers
@@ -32,6 +33,7 @@ func (app *ChainApp) RegisterUpgradeHandlers() {
 		IBCKeeper:             app.IBCKeeper,
 		Codec:                 app.appCodec,
 		GetStoreKey:           app.GetKey,
+		GlobalFeeKeeper:       &app.GlobalFeeKeeper,
 	}
 	app.GetStoreKeys()
 	// register all upgrade handlers

--- a/app/upgrades/types.go
+++ b/app/upgrades/types.go
@@ -17,6 +17,7 @@ import (
 	bankkeeper "github.com/cosmos/cosmos-sdk/x/bank/keeper"
 	consensusparamkeeper "github.com/cosmos/cosmos-sdk/x/consensus/keeper"
 	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
+	globalfeekeeper "github.com/strangelove-ventures/globalfee/x/globalfee/keeper"
 )
 
 type AppKeepers struct {
@@ -30,6 +31,9 @@ type AppKeepers struct {
 	CapabilityKeeper      *capabilitykeeper.Keeper
 	IBCKeeper             *ibckeeper.Keeper
 	CommitMultiStore      storetypes.CommitMultiStore
+
+	// GlobalFeeKeeper allows upgrade handlers to set globalfee params.
+	GlobalFeeKeeper *globalfeekeeper.Keeper
 }
 type ModuleManager interface {
 	RunMigrations(ctx context.Context, cfg module.Configurator, fromVM module.VersionMap) (module.VersionMap, error)
@@ -51,6 +55,10 @@ type Upgrade struct {
 
 // Fork defines a struct containing the requisite fields for a non-software upgrade proposal
 // Hard Fork at a given height to implement.
+// There is one time code that can be added for the start of the Fork, in `BeginForkLogic`.
+// Any other change in the code should be height-gated, if the goal is to have old and new binaries
+// to be compatible prior to the upgrade handler.
+//
 // There is one time code that can be added for the start of the Fork, in `BeginForkLogic`.
 // Any other change in the code should be height-gated, if the goal is to have old and new binaries
 // to be compatible prior to the upgrade height.

--- a/app/upgrades/v6/constants.go
+++ b/app/upgrades/v6/constants.go
@@ -1,0 +1,20 @@
+package v6
+
+import (
+	storetypes "cosmossdk.io/store/types"
+	"github.com/Crypto-Dungeon/dungeonchain/app/upgrades"
+)
+
+const (
+	// UpgradeName defines the on-chain upgrade name for governance proposal.
+	UpgradeName = "v6"
+)
+
+var Upgrade = upgrades.Upgrade{
+	UpgradeName:          UpgradeName,
+	CreateUpgradeHandler: CreateUpgradeHandler,
+	StoreUpgrades: storetypes.StoreUpgrades{
+		Added:   []string{},
+		Deleted: []string{},
+	},
+}

--- a/app/upgrades/v6/upgrades.go
+++ b/app/upgrades/v6/upgrades.go
@@ -1,0 +1,89 @@
+package v6
+
+import (
+	"context"
+	"fmt"
+
+	sdkmath "cosmossdk.io/math"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
+
+	"github.com/Crypto-Dungeon/dungeonchain/app/upgrades"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module"
+	globalfeetypes "github.com/strangelove-ventures/globalfee/x/globalfee/types"
+)
+
+// adminAddress is the Dungeon admin wallet that is exempt from minimum gas fees.
+// This allows the admin to execute governance, upgrade, and operational transactions
+// without needing to hold fee tokens during bootstrapping phases.
+// The exemption is enforced in the ante chain (app/decorators/fee_exempt.go) at
+// binary startup, not via on-chain state.
+const adminAddress = "dungeon13x4pynlp86prhcmtns742kgsgu7pjtzj72eycc"
+
+// minimumGasPrice* are the on-chain minimum gas price params set by v6.
+// Prior to v6 the globalfee minimum was 0 (free transactions for all).
+// After v6 non-exempt addresses must attach at least 0.01udgn per gas unit.
+const minimumGasPriceDenom = "udgn"
+const minimumGasPriceAmount = "0.010000000000000000"
+
+// CreateUpgradeHandler returns the v6 upgrade handler which:
+//  1. Sets x/globalfee MinimumGasPrices to 0.01udgn (enables fee enforcement).
+//  2. Logs confirmation that admin fee exemption is wired in the binary ante chain.
+//
+// NOTE on ExemptAddresses: the globalfee Params proto struct has no
+// ExemptAddresses field without a proto regeneration + store migration. The
+// exemption is implemented as an in-process ante decorator (FeeExemptionAnteDecorator)
+// initialized from ChainApp.FeeExemptAddresses at startup. No on-chain state needed.
+//
+// NOTE on LSM params: ValidatorBondFactor, GlobalLiquidStakingCap, and
+// ValidatorLiquidStakingCap are NOT present in cosmos-sdk v0.50.13 vanilla.
+// They live in the Cosmos Hub LSM fork of x/staking. Wire them here if/when
+// dungeon-1 merges that fork. Tracked as TODO.
+func CreateUpgradeHandler(
+	mm upgrades.ModuleManager,
+	configurator module.Configurator,
+	ak *upgrades.AppKeepers,
+) upgradetypes.UpgradeHandler {
+	return func(ctx context.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		sdkCtx := sdk.UnwrapSDKContext(ctx)
+		logger := sdkCtx.Logger().With("upgrade", UpgradeName)
+
+		// 1. Set globalfee minimum gas price to 0.01udgn.
+		if ak.GlobalFeeKeeper != nil {
+			amount, err := sdkmath.LegacyNewDecFromStr(minimumGasPriceAmount)
+			if err != nil {
+				return nil, fmt.Errorf("v6 upgrade: invalid minimum gas price amount %q: %w", minimumGasPriceAmount, err)
+			}
+			newParams := globalfeetypes.Params{
+				MinimumGasPrices: sdk.DecCoins{
+					sdk.NewDecCoinFromDec(minimumGasPriceDenom, amount),
+				},
+			}
+			if err := ak.GlobalFeeKeeper.SetParams(sdkCtx, newParams); err != nil {
+				return nil, fmt.Errorf("v6 upgrade: failed to set globalfee params: %w", err)
+			}
+			logger.Info("globalfee minimum gas price set",
+				"denom", minimumGasPriceDenom,
+				"amount", minimumGasPriceAmount,
+			)
+		} else {
+			logger.Error("GlobalFeeKeeper is nil — skipping globalfee param update")
+		}
+
+		// 2. Fee exemption for admin address is handled by FeeExemptionAnteDecorator,
+		//    not on-chain state. Restart all validators with v6 binary — the exempt
+		//    address is wired at app initialization in app.go.
+		logger.Info("v6: admin fee exemption active via ante chain on v6 binary",
+			"exempt_address", adminAddress,
+		)
+
+		// TODO(lee): LSM staking params
+		// - ValidatorBondFactor    = 250
+		// - GlobalLiquidStakingCap = "0.25"
+		// - ValidatorLiquidStakingCap = "0.5"
+		// Requires merging the Cosmos Hub LSM fork of x/staking into dungeonchain.
+		// cosmos-sdk v0.50.13 vanilla does NOT include LSM.
+
+		return mm.RunMigrations(ctx, configurator, fromVM)
+	}
+}

--- a/chains/testnet.json
+++ b/chains/testnet.json
@@ -65,7 +65,7 @@
             "denom": "udgn",
             "trusting_period": "336h",
             "debugging": false,
-            "block_time": "2000ms",
+            "block_time": "1500ms",
             "host_port_override": {
                 "1317": "1317",
                 "26656": "26656",
@@ -140,7 +140,7 @@
             "denom": "uatom",
             "trusting_period": "336h",
             "debugging": true,
-            "block_time": "2000ms",
+            "block_time": "1500ms",
             "ics_version_override": {}
         }
     ]

--- a/scripts/test_ics_node.sh
+++ b/scripts/test_ics_node.sh
@@ -102,6 +102,10 @@ from_scratch () {
     $BINARY genesis add-genesis-account $KEY 10000000$DENOM,900test --keyring-backend $KEYRING --home $HOME_DIR --append
     $BINARY genesis add-genesis-account $KEY2 10000000$DENOM,800test --keyring-backend $KEYRING --home $HOME_DIR --append
 
+    # Create validator gentx and collect
+    $BINARY genesis gentx $KEY 5000000$DENOM --chain-id $CHAIN_ID --keyring-backend $KEYRING --home $HOME_DIR
+    $BINARY genesis collect-gentxs --home $HOME_DIR
+
 }
 
 # check if CLEAN is not set to false

--- a/scripts/test_ics_node.sh
+++ b/scripts/test_ics_node.sh
@@ -102,18 +102,6 @@ from_scratch () {
     $BINARY genesis add-genesis-account $KEY 10000000$DENOM,900test --keyring-backend $KEYRING --home $HOME_DIR --append
     $BINARY genesis add-genesis-account $KEY2 10000000$DENOM,800test --keyring-backend $KEYRING --home $HOME_DIR --append
 
-    # ICS provider genesis hack
-    HACK_DIR=icshack-1 && echo $HACK_DIR
-    rm -rf $HACK_DIR
-    cp -r ${HOME_DIR} $HACK_DIR
-
-    $BINARY add-consumer-section provider --home $HACK_DIR
-    ccvjson=`jq '.app_state["ccvconsumer"]' $HACK_DIR/config/genesis.json`
-    echo $ccvjson
-    jq '.app_state["ccvconsumer"] = '"$ccvjson"  ${HACK_DIR}/config/genesis.json > json.tmp && mv json.tmp $genesis_json
-    rm -rf $HACK_DIR
-
-    update_test_genesis `printf '.app_state["ccvconsumer"]["params"]["unbonding_period"]="%s"' "240s"`
 }
 
 # check if CLEAN is not set to false

--- a/scripts/test_ics_node.sh
+++ b/scripts/test_ics_node.sh
@@ -144,5 +144,6 @@ sed -i -e 's/address = ":8080"/address = "0.0.0.0:'$ROSETTA'"/g' $HOME_DIR/confi
 # Faster blocks
 sed -i -e 's/timeout_commit = "5s"/timeout_commit = "'$BLOCK_TIME'"/g' $HOME_DIR/config/config.toml
 
+sed -i -e 's/timeout_propose = "3s"/timeout_propose = "2s"/g' $HOME_DIR/config/config.toml
 # Start the daemon in the background
 $BINARY start --pruning=nothing  --minimum-gas-prices=0$DENOM --rpc.laddr="tcp://0.0.0.0:$RPC" --home $HOME_DIR

--- a/scripts/test_v6_upgrade.sh
+++ b/scripts/test_v6_upgrade.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+# test_v6_upgrade.sh — Simulate v5 -> v6 chain upgrade on an isolated testnet.
+#
+# What this verifies:
+#   1. A chain booted with the v5 binary halts at the upgrade height.
+#   2. Restarting with the v6 binary resumes block production.
+#   3. The v6 handler sets x/globalfee MinimumGasPrices to 0.01udgn.
+#   4. Fee enforcement post-upgrade: a non-exempt tx with --gas-prices=0udgn
+#      is rejected; the same tx with --gas-prices=0.01udgn succeeds.
+#
+# Not yet verified (needs app.go env-var hook, separate change):
+#   - Admin-wallet fee exemption (production hardcoded address; no test key).
+#
+# Ports chosen to NOT collide with the live dungeond on server 11
+# (26657/26656/9090/11317).
+set -eu
+
+BINARY_V5=${BINARY_V5:-$HOME/bin/dungeond-v5}
+BINARY_V6=${BINARY_V6:-$HOME/bin/dungeond-v6}
+HOME_DIR=${HOME_DIR:-$HOME/.dungeonchain-v6test}
+CHAIN_ID=${CHAIN_ID:-dungeontest-1}
+DENOM=${DENOM:-udgn}
+KEYRING=test
+
+RPC_PORT=${RPC_PORT:-46657}
+P2P_PORT=${P2P_PORT:-46656}
+GRPC_PORT=${GRPC_PORT:-19090}
+GRPC_WEB_PORT=${GRPC_WEB_PORT:-19091}
+REST_PORT=${REST_PORT:-21317}
+PPROF_PORT=${PPROF_PORT:-36060}
+
+LOG_DIR=$HOME_DIR/test-logs
+UPGRADE_OFFSET=${UPGRADE_OFFSET:-40}
+VOTING_PERIOD=30s
+EXPEDITED_VOTING_PERIOD=15s
+BLOCK_TIME=${BLOCK_TIME:-2s}
+
+say() { echo "[$(date +%H:%M:%S)] $*"; }
+die() { echo "FAIL: $*" >&2; exit 1; }
+
+for bin in "$BINARY_V5" "$BINARY_V6"; do
+  [ -x "$bin" ] || die "binary not found/executable: $bin"
+done
+command -v jq >/dev/null || die "jq is required"
+
+say "--- killing any leftover testnet daemons ---"
+pkill -f 'dungeond-v[56] .*--home.*v6test' 2>/dev/null || true
+# Also by port
+fuser -k $RPC_PORT/tcp 2>/dev/null || true
+sleep 2
+
+say "--- wiping $HOME_DIR ---"
+[ ${#HOME_DIR} -gt 5 ] || die "HOME_DIR too short, refusing to rm"
+rm -rf "$HOME_DIR"
+mkdir -p "$LOG_DIR"
+
+BIN5=("$BINARY_V5" --home "$HOME_DIR")
+BIN6=("$BINARY_V6" --home "$HOME_DIR")
+KR=(--keyring-backend $KEYRING)
+NODE_URL="tcp://127.0.0.1:$RPC_PORT"
+
+say "--- init chain (v5) ---"
+"${BIN5[@]}" init localval --chain-id $CHAIN_ID --default-denom $DENOM > /dev/null 2>&1
+
+"${BIN5[@]}" keys add val "${KR[@]}" --output json > $LOG_DIR/val.json 2>&1
+"${BIN5[@]}" keys add user "${KR[@]}" --output json > $LOG_DIR/user.json 2>&1
+VAL_ADDR=$("${BIN5[@]}" keys show val "${KR[@]}" -a)
+USER_ADDR=$("${BIN5[@]}" keys show user "${KR[@]}" -a)
+say "  validator: $VAL_ADDR"
+say "  user:      $USER_ADDR"
+
+"${BIN5[@]}" genesis add-genesis-account val 1000000000000$DENOM "${KR[@]}"
+"${BIN5[@]}" genesis add-genesis-account user 1000000000$DENOM "${KR[@]}"
+
+"${BIN5[@]}" genesis gentx val 100000000000$DENOM --chain-id $CHAIN_ID "${KR[@]}" > /dev/null 2>&1
+"${BIN5[@]}" genesis collect-gentxs > /dev/null 2>&1
+
+GEN=$HOME_DIR/config/genesis.json
+tmp=$(mktemp)
+jq ".app_state.gov.params.voting_period=\"$VOTING_PERIOD\" |
+    .app_state.gov.params.expedited_voting_period=\"$EXPEDITED_VOTING_PERIOD\" |
+    .app_state.gov.params.min_deposit=[{\"denom\":\"$DENOM\",\"amount\":\"1\"}] |
+    .app_state.gov.params.expedited_min_deposit=[{\"denom\":\"$DENOM\",\"amount\":\"1\"}] |
+    .app_state.globalfee.params.minimum_gas_prices=[{\"denom\":\"$DENOM\",\"amount\":\"0.000000000000000000\"}]" $GEN > $tmp && mv $tmp $GEN
+
+CFG=$HOME_DIR/config/config.toml
+sed -i "s#^laddr = \"tcp://127.0.0.1:26657\"#laddr = \"tcp://127.0.0.1:$RPC_PORT\"#" $CFG
+sed -i "s#^laddr = \"tcp://0.0.0.0:26656\"#laddr = \"tcp://0.0.0.0:$P2P_PORT\"#" $CFG
+sed -i "s#^pprof_laddr = \"localhost:6060\"#pprof_laddr = \"localhost:$PPROF_PORT\"#" $CFG
+sed -i "s#^timeout_commit = \"5s\"#timeout_commit = \"$BLOCK_TIME\"#" $CFG
+sed -i "s#^cors_allowed_origins = \\[\\]#cors_allowed_origins = [\"*\"]#" $CFG
+
+APP=$HOME_DIR/config/app.toml
+sed -i "s#^address = \"tcp://localhost:1317\"#address = \"tcp://localhost:$REST_PORT\"#" $APP
+sed -i "s#^address = \"localhost:9090\"#address = \"localhost:$GRPC_PORT\"#" $APP
+sed -i "s#^address = \"localhost:9091\"#address = \"localhost:$GRPC_WEB_PORT\"#" $APP
+sed -i "s#^minimum-gas-prices = \"\"#minimum-gas-prices = \"0$DENOM\"#" $APP
+sed -i "/^\\[api\\]/,/^\\[/{s/^enable = false/enable = true/;}" $APP
+
+say "--- starting v5 daemon ---"
+nohup "${BIN5[@]}" start \
+  --pruning=nothing \
+  --minimum-gas-prices=0$DENOM \
+  > $LOG_DIR/v5.log 2>&1 &
+V5_PID=$!
+say "  v5 pid=$V5_PID, waiting for block 5"
+
+wait_height() {
+  local target=$1 timeout=${2:-120}
+  local start=$(date +%s)
+  while true; do
+    h=$(curl -s http://127.0.0.1:$RPC_PORT/status 2>/dev/null | jq -r '.result.sync_info.latest_block_height // "0"')
+    if [ -n "$h" ] && [ "$h" != "null" ] && [ "$h" -ge "$target" ] 2>/dev/null; then
+      echo $h
+      return 0
+    fi
+    now=$(date +%s)
+    [ $((now-start)) -gt $timeout ] && die "timeout waiting for height $target (at $h)"
+    sleep 1
+  done
+}
+
+wait_height 5 60 > /dev/null
+say "  chain is producing blocks"
+
+CUR=$(curl -s http://127.0.0.1:$RPC_PORT/status | jq -r '.result.sync_info.latest_block_height')
+UP_HEIGHT=$((CUR + UPGRADE_OFFSET))
+say "--- submitting upgrade prop: v6 at height $UP_HEIGHT (current $CUR) ---"
+
+PROP_FILE=$LOG_DIR/prop.json
+AUTHORITY=$("${BIN5[@]}" query auth module-account gov --node $NODE_URL -o json 2>/dev/null | jq -r '.account.value.address' 2>/dev/null)
+[ -n "$AUTHORITY" ] && [ "$AUTHORITY" != "null" ] || AUTHORITY="dungeon10d07y265gmmuvt4z0w9aw880jnsr700j53vrug"
+say "  authority: $AUTHORITY"
+
+cat > $PROP_FILE <<PROPEOF
+{
+  "messages": [
+    {
+      "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+      "authority": "$AUTHORITY",
+      "plan": {
+        "name": "v6",
+        "height": "$UP_HEIGHT",
+        "info": "test upgrade",
+        "upgraded_client_state": null
+      }
+    }
+  ],
+  "metadata": "",
+  "deposit": "1$DENOM",
+  "title": "v6 test upgrade",
+  "summary": "scripted v5 to v6 upgrade test"
+}
+PROPEOF
+
+"${BIN5[@]}" tx gov submit-proposal $PROP_FILE --from val --chain-id $CHAIN_ID "${KR[@]}" \
+  --node $NODE_URL --gas auto --gas-adjustment 1.5 --fees 10000$DENOM -y -o json \
+  > $LOG_DIR/submit.json 2>&1 || true
+sleep 6
+
+PROP_ID=$("${BIN5[@]}" query gov proposals --node $NODE_URL -o json 2>/dev/null | jq -r '.proposals[-1].id')
+say "  prop id=$PROP_ID"
+[ -n "$PROP_ID" ] && [ "$PROP_ID" != "null" ] || die "failed to submit proposal (see $LOG_DIR/submit.json)"
+
+say "--- voting yes ---"
+"${BIN5[@]}" tx gov vote $PROP_ID yes --from val --chain-id $CHAIN_ID "${KR[@]}" \
+  --node $NODE_URL --gas auto --gas-adjustment 1.5 --fees 10000$DENOM -y > $LOG_DIR/vote.json 2>&1
+sleep 4
+
+say "--- waiting for upgrade halt at height $UP_HEIGHT ---"
+for i in $(seq 1 600); do
+  if ! kill -0 $V5_PID 2>/dev/null; then
+    say "  v5 process exited"
+    break
+  fi
+  if grep -qE 'UPGRADE "v6" NEEDED|ERR CONSENSUS FAILURE' $LOG_DIR/v5.log 2>/dev/null; then
+    say "  upgrade panic observed in log"
+    for j in $(seq 1 10); do
+      kill -0 $V5_PID 2>/dev/null || break
+      sleep 1
+    done
+    break
+  fi
+  sleep 2
+done
+kill $V5_PID 2>/dev/null || true
+sleep 3
+
+say "--- starting v6 daemon (same home) ---"
+nohup "${BIN6[@]}" start \
+  --pruning=nothing \
+  --minimum-gas-prices=0$DENOM \
+  > $LOG_DIR/v6.log 2>&1 &
+V6_PID=$!
+say "  v6 pid=$V6_PID, waiting for height > $UP_HEIGHT"
+NEW_H=$(wait_height $((UP_HEIGHT+3)) 180)
+say "  chain resumed, at height $NEW_H"
+
+say "--- assertion 1: globalfee MinimumGasPrices = 0.01$DENOM ---"
+GF_JSON=$("${BIN6[@]}" query globalfee minimum-gas-prices --node $NODE_URL -o json 2>&1)
+echo "$GF_JSON" > $LOG_DIR/globalfee.json
+GF_AMT=$(echo "$GF_JSON" | jq -r '.minimum_gas_prices[0].amount // .params.minimum_gas_prices[0].amount // ""')
+GF_DENOM=$(echo "$GF_JSON" | jq -r '.minimum_gas_prices[0].denom // .params.minimum_gas_prices[0].denom // ""')
+say "  globalfee = $GF_AMT$GF_DENOM"
+[ "$GF_DENOM" = "$DENOM" ] || die "unexpected denom: $GF_DENOM"
+case "$GF_AMT" in
+  0.01*) ;;
+  *) die "expected MinimumGasPrices ~0.01$DENOM, got $GF_AMT$GF_DENOM" ;;
+esac
+say "  OK"
+
+say "--- assertion 2: zero-fee tx is rejected ---"
+ZERO_OUT=$("${BIN6[@]}" tx bank send user $VAL_ADDR 1$DENOM \
+  --chain-id $CHAIN_ID --node $NODE_URL "${KR[@]}" \
+  --gas 200000 --gas-prices 0$DENOM -y -o json 2>&1 || true)
+echo "$ZERO_OUT" > $LOG_DIR/zero_fee.json
+if echo "$ZERO_OUT" | grep -qiE 'insufficient fee|provided fee|minimum-gas-prices|below minimum'; then
+  say "  rejected as expected"
+else
+  CODE=$(echo "$ZERO_OUT" | jq -r '.code // empty' 2>/dev/null)
+  if [ -n "$CODE" ] && [ "$CODE" != "0" ]; then
+    say "  rejected with code $CODE"
+  else
+    die "zero-fee tx was NOT rejected (see $LOG_DIR/zero_fee.json)"
+  fi
+fi
+
+say "--- assertion 3: 0.01$DENOM fee tx succeeds ---"
+OK_OUT=$("${BIN6[@]}" tx bank send user $VAL_ADDR 1$DENOM \
+  --chain-id $CHAIN_ID --node $NODE_URL "${KR[@]}" \
+  --gas 200000 --gas-prices 0.01$DENOM -y -o json 2>&1)
+echo "$OK_OUT" > $LOG_DIR/paid_fee.json
+CODE=$(echo "$OK_OUT" | jq -r '.code')
+[ "$CODE" = "0" ] || die "paid-fee tx failed with code $CODE (see $LOG_DIR/paid_fee.json)"
+say "  accepted, code=0"
+
+say ""
+say "========================================="
+say "  v6 UPGRADE TEST PASSED"
+say "========================================="
+say "  logs: $LOG_DIR/"
+say "  v6 still running as pid $V6_PID (kill with: kill $V6_PID)"


### PR DESCRIPTION
## Summary

- **globalfee minimum gas price = 0.01udgn** (currently 0; eliminates retry-loop bot spam)
- **Fee-exempt addresses** (zero-fee txs allowed):
  - Admin/treasury: \`dungeon13x4pynlp86prhcmtns742kgsgu7pjtzj72eycc\`
  - BTC relayer: \`dungeon1dflpa6dnpkn5ft4tyzkpwdhvz6l7wng06qn665\` (added in this commit)
- **1500ms block time** (faster casino + DEX UX)
- Dead IBC channel JSON config files removed (cosmetic)

## Test plan

- [x] \`make build\` clean
- [x] \`./scripts/test_v6_upgrade.sh\` — all 3 assertions pass:
  1. globalfee MinimumGasPrices = 0.01udgn after upgrade
  2. Zero-fee tx rejected post-upgrade
  3. 0.01udgn fee tx accepted
- [ ] After merge: gov prop on dungeon-1 mainnet at target height ~14897525

## Notes

This upgrade does NOT change SDK or wasmd versions — those are deferred to v7 alongside Alliance module + bulk-memory wasm capability (the actual bridge unblock).